### PR TITLE
security(encryption): add key zeroization for memory protection

### DIFF
--- a/docs/encryption-architecture.md
+++ b/docs/encryption-architecture.md
@@ -62,3 +62,4 @@ Old keys preserved for decrypting existing backups.
 | Authenticity | AEAD with transfer ID binding |
 | Key Protection | PKCS12 keystore + Argon2id |
 | IV Uniqueness | SecureRandom per chunk |
+| Memory Protection | Key zeroization after use |


### PR DESCRIPTION
- Zero out key copies after encrypt/decrypt operations
- Zero IVs and encrypted data after use in finally blocks
- Update docs to reflect memory protection feature
- Argon2id already zeroes password bytes